### PR TITLE
Enable PDF export from preview

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -39,6 +39,10 @@ Instead, it will copy all the configuration files and the transitive dependencie
 
 You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
 
+## PDF Export
+
+When viewing the visualization preview there is a **Download PDF** button in the header. Clicking it opens the browser's print dialog where each preview tab is rendered on a separate A4 page.
+
 ## Learn More
 
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,7 +41,7 @@ You don't have to ever use `eject`. The curated feature set is suitable for smal
 
 ## PDF Export
 
-When viewing the visualization preview there is a **Download PDF** button in the header. Clicking it opens the browser's print dialog where each preview tab is rendered on its own A4 page. The dashboard header is automatically hidden and each page begins with the appropriate section title.
+When viewing the visualization preview there is a **Download PDF** button in the header. Clicking it opens the browser's print dialog where each preview tab is rendered on its own A4 page. The dashboard header is automatically hidden. Each page is vertically centered and begins with a large "Neuropsychologisch Onderzoek" title followed by the section subtitle.
 
 ## Learn More
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,7 +41,7 @@ You don't have to ever use `eject`. The curated feature set is suitable for smal
 
 ## PDF Export
 
-When viewing the visualization preview there is a **Download PDF** button in the header. Clicking it opens the browser's print dialog where each preview tab is rendered on a separate A4 page.
+When viewing the visualization preview there is a **Download PDF** button in the header. Clicking it opens the browser's print dialog where each preview tab is rendered on its own A4 page. The dashboard header is automatically hidden and each page begins with the appropriate section title.
 
 ## Learn More
 

--- a/frontend/src/components/DashboardHeader.js
+++ b/frontend/src/components/DashboardHeader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Save, Eye, Edit, ArrowLeftCircle } from 'lucide-react'; // ArrowLeftCircle toegevoegd
+import { Save, Eye, Edit, ArrowLeftCircle, Printer } from 'lucide-react';
 import EmojiSizeControl from './EmojiSizeControl';
 
 const DashboardHeader = ({ 
@@ -52,6 +52,15 @@ const DashboardHeader = ({
             <Save className="mr-2" size={18} />
             Opslaan
           </button>
+          {previewMode && (
+            <button
+              className="px-4 py-2 bg-purple-500 hover:bg-purple-600 rounded-md flex items-center"
+              onClick={() => window.print()}
+            >
+              <Printer className="mr-2" size={18} />
+              Download PDF
+            </button>
+          )}
         </div>
       </div>
     </header>

--- a/frontend/src/components/DashboardHeader.js
+++ b/frontend/src/components/DashboardHeader.js
@@ -11,7 +11,7 @@ const DashboardHeader = ({
   onCloseDashboard // Nieuwe prop
 }) => {
   return (
-    <header className="bg-blue-700 text-white p-4">
+    <header className="bg-blue-700 text-white p-4 no-print">
       <div className="container mx-auto flex justify-between items-center">
         <div className="flex items-center">
           {onCloseDashboard && (

--- a/frontend/src/components/preview/PreviewTabs.js
+++ b/frontend/src/components/preview/PreviewTabs.js
@@ -43,15 +43,18 @@ const PreviewTabs = ({ formData, klachten, belangrijksteBevindingen, praktischeA
         ))}
       </div>
 
-      <div className={`tab-content ${activeTab === 'voorblad' ? '' : 'hidden'} page-break`}>
+      <div className={`tab-content print-page ${activeTab === 'voorblad' ? '' : 'hidden'} page-break`}>
+        <h1 className="print-main-title">Neuropsychologisch Onderzoek</h1>
         <h2 className="print-section-title">Voorblad</h2>
         <PatientInfoCard formData={formData} klachten={klachten} emojiSize={emojiSize} />
       </div>
-      <div className={`tab-content ${activeTab === 'onderzoeksresultaten' ? '' : 'hidden'} page-break`}>
+      <div className={`tab-content print-page ${activeTab === 'onderzoeksresultaten' ? '' : 'hidden'} page-break`}>
+        <h1 className="print-main-title">Neuropsychologisch Onderzoek</h1>
         <h2 className="print-section-title">Onderzoeksresultaten</h2>
         <IntelligenceResultsCard formData={formData} emojiSize={emojiSize} />
       </div>
-      <div className={`tab-content ${activeTab === 'conclusie' ? '' : 'hidden'}`}>
+      <div className={`tab-content print-page ${activeTab === 'conclusie' ? '' : 'hidden'}`}>
+        <h1 className="print-main-title">Neuropsychologisch Onderzoek</h1>
         <h2 className="print-section-title">Conclusie &amp; Behandeling</h2>
         <ConclusieCard
           formData={formData}

--- a/frontend/src/components/preview/PreviewTabs.js
+++ b/frontend/src/components/preview/PreviewTabs.js
@@ -44,12 +44,15 @@ const PreviewTabs = ({ formData, klachten, belangrijksteBevindingen, praktischeA
       </div>
 
       <div className={`tab-content ${activeTab === 'voorblad' ? '' : 'hidden'} page-break`}>
+        <h2 className="print-section-title">Voorblad</h2>
         <PatientInfoCard formData={formData} klachten={klachten} emojiSize={emojiSize} />
       </div>
       <div className={`tab-content ${activeTab === 'onderzoeksresultaten' ? '' : 'hidden'} page-break`}>
+        <h2 className="print-section-title">Onderzoeksresultaten</h2>
         <IntelligenceResultsCard formData={formData} emojiSize={emojiSize} />
       </div>
       <div className={`tab-content ${activeTab === 'conclusie' ? '' : 'hidden'}`}>
+        <h2 className="print-section-title">Conclusie &amp; Behandeling</h2>
         <ConclusieCard
           formData={formData}
           belangrijksteBevindingen={belangrijksteBevindingen}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -38,6 +38,10 @@ input[type=number] {
 }
 
 @media print {
+  @page {
+    margin: 0;
+  }
+
   .no-print {
     display: none !important;
   }
@@ -49,7 +53,9 @@ input[type=number] {
   }
 
   .print-page {
-    @apply flex flex-col items-center justify-center h-screen;
+    @apply flex flex-col items-center justify-center;
+    min-height: 100vh;
+    width: 100%;
   }
 
   .print-section-title {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,8 +24,13 @@ input[type=number]::-webkit-inner-spin-button {
 }
 
 /* Verberg de pijltjes bij number inputs in Firefox */
+
 input[type=number] {
   -moz-appearance: textfield;
+}
+
+.print-section-title {
+  display: none;
 }
 
 @media print {
@@ -37,5 +42,23 @@ input[type=number] {
   }
   .page-break {
     page-break-after: always;
+  }
+
+  .print-section-title {
+    @apply text-2xl font-bold mb-4;
+    display: block;
+  }
+
+  /* Gebruik volledige breedte en behoud kleuren */
+  body {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .container {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 0 !important;
+    margin: 0 !important;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,6 +33,10 @@ input[type=number] {
   display: none;
 }
 
+.print-main-title {
+  display: none;
+}
+
 @media print {
   .no-print {
     display: none !important;
@@ -44,8 +48,17 @@ input[type=number] {
     page-break-after: always;
   }
 
+  .print-page {
+    @apply flex flex-col items-center justify-center h-screen;
+  }
+
   .print-section-title {
     @apply text-2xl font-bold mb-4;
+    display: block;
+  }
+
+  .print-main-title {
+    @apply text-4xl font-bold mb-2;
     display: block;
   }
 


### PR DESCRIPTION
## Summary
- add a print button to DashboardHeader that opens the browser print dialog
- update README with usage notes on generating PDFs

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685032f6f98883289b3a9e9cb72ea74c